### PR TITLE
Refactoring GOJA

### DIFF
--- a/goja/.clang-format
+++ b/goja/.clang-format
@@ -1,0 +1,8 @@
+UseTab: Never
+TabWidth: 2
+Standard: Cpp11
+IndentWidth: 2
+PointerBindsToType: true
+ColumnLimit: 150
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBraces: Allman

--- a/goja/CMakeLists.txt
+++ b/goja/CMakeLists.txt
@@ -9,7 +9,7 @@ add_definitions(-std=c++14 -Wall -Wunused-parameter)
 # Searching for dependencies:
 
 list(APPEND CMAKE_MODULE_PATH $ENV{ROOTSYS}/etc/cmake)
-find_package(ROOT 6.24 REQUIRED COMPONENTS Tree)
+find_package(ROOT 6.22 REQUIRED COMPONENTS Tree)
 if(ROOT_USE_FILE)
   include(${ROOT_USE_FILE})
 endif()

--- a/goja/Common.h
+++ b/goja/Common.h
@@ -1,13 +1,17 @@
+#ifndef Common_h
+#define Common_h
+
 //================================================================================
 // CONSTANTS
 //================================================================================
 
-#define c 299792458.    // speed of light in vacuum [m/s]
-#define n 1.58          // refractive index of the EJ230 material [1/1]
-#define v c/n           // speed of light in the EJ230 material [m/s]
+const double c = 299792458;   // speed of light in vacuum [m/s]
+const double n =  1.58;          // refractive index of the EJ230 material [1/1]
+const double v = c/n;           // speed of light in the EJ230 material [m/s]
 
 //================================================================================
 // DEBUG
 //================================================================================
 
 #define DEBUG 0
+#endif

--- a/goja/EventAnalysis.cpp
+++ b/goja/EventAnalysis.cpp
@@ -5,6 +5,8 @@
 
 #include "EventAnalysis.h"
 
+using namespace std;
+
 //================================================================================
 // MATHEMATICAL AND ADDITIONAL FUNCTIONS
 //================================================================================
@@ -112,7 +114,7 @@ EventAnalysis::EventAnalysis() {
 
 }
 
-void EventAnalysis::select_coincident_hits(vector<Hit> &hits) {
+void EventAnalysis::select_coincident_hits(const vector<Hit> &hits) {
 
   double COMPTON_E_TH = atof(getenv("GOJA_COMPTON_E_TH"))*1e3;
 
@@ -160,7 +162,7 @@ void EventAnalysis::select_coincident_singles(const std::vector<Hit> &hits) {
 
 }
 
-EventType EventAnalysis::verify_type_of_coincidence(Hit &h1, Hit &h2) {
+EventType EventAnalysis::verify_type_of_coincidence(const Hit &h1,const  Hit &h2) const {
 
   EventType t = kUnspecified;
 

--- a/goja/EventAnalysis.cpp
+++ b/goja/EventAnalysis.cpp
@@ -119,8 +119,6 @@ Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner = kCen
   return h;
 }
 
-
-
 namespace event_analysis{
 
 
@@ -156,20 +154,14 @@ std::tuple<int, int, std::vector<Hit>>  select_coincident_singles(const std::vec
     }
   }
 
+  /// WK: Why it is always centroid here?
   vector<Hit> singles;
   map<string, vector<Hit>>::iterator it_tmp = singles_tmp.begin();
   while(it_tmp != singles_tmp.end()) {
     singles.push_back(merge_hits(it_tmp->second, kCentroidWinnerEnergyWeightedFirstTime));
     it_tmp++;
   }
-
-  int nb_above_noise_treshold = singles.size();
-  std::vector<Hit> selected_hits;
-  for (unsigned int i=0; i<singles.size(); i++) {
-    if (singles[i].edep>compton_energy_threshold) selected_hits.push_back(singles[i]);
-  }
-  int nb_above_compton_threshold = selected_hits.size();
-  return std::make_tuple(nb_above_noise_treshold, nb_above_compton_threshold, selected_hits);
+  return select_coincident_hits(singles, compton_energy_threshold);
 }
 
 EventType verify_type_of_coincidence(const Hit &h1,const  Hit &h2) {
@@ -250,10 +242,10 @@ void analyze_event(vector<Hit> &hits, bool hits_are_singles)
 
   std::vector<Hit> selected_hits;
   if (hits_are_singles) {
-    std::tie(N0, N, selected_hits)=select_coincident_singles(hits, COMPTON_E_TH);
+    std::tie(N0, N, selected_hits) = select_coincident_singles(hits, COMPTON_E_TH);
   }
   else {
-    std::tie(N0, N, selected_hits)= select_coincident_hits(hits, COMPTON_E_TH);
+    std::tie(N0, N, selected_hits) = select_coincident_hits(hits, COMPTON_E_TH);
   }
 
   /// WK: Why N==MAX_N and N0<=MAX_N0

--- a/goja/EventAnalysis.cpp
+++ b/goja/EventAnalysis.cpp
@@ -43,8 +43,11 @@ Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner = kCen
   h.eventID = hits[0].eventID;
   h.volumeID = hits[0].volumeID;
   for (unsigned int i=0; i<nHits; i++) h.edep += hits[i].edep;
-  if (winner == kCentroidWinnerNaivelyWeighted) {
-    for (unsigned int i=0; i<nHits; i++) {
+
+  switch (winner) {
+
+  case kCentroidWinnerNaivelyWeighted: {
+    for (unsigned int i = 0; i < nHits; i++) {
       h.time += hits[i].time;
       h.posX += hits[i].posX;
       h.posY += hits[i].posY;
@@ -54,9 +57,11 @@ Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner = kCen
     h.posX /= nHits;
     h.posY /= nHits;
     h.posZ /= nHits;
+    break;
   }
-  else if (winner == kCentroidWinnerEnergyWeighted) {
-    for (unsigned int i=0; i<nHits; i++) {
+
+  case kCentroidWinnerEnergyWeighted: {
+    for (unsigned int i = 0; i < nHits; i++) {
       h.time += hits[i].time * hits[i].edep;
       h.posX += hits[i].posX * hits[i].edep;
       h.posY += hits[i].posY * hits[i].edep;
@@ -66,14 +71,17 @@ Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner = kCen
     h.posX /= h.edep;
     h.posY /= h.edep;
     h.posZ /= h.edep;
+    break;
   }
-  else if (winner == kCentroidWinnerEnergyWeightedFirstTime) {
+
+  case kCentroidWinnerEnergyWeightedFirstTime: {
     std::vector<double> times;
-    for (unsigned int i = 0; i<nHits; i++) times.push_back(hits[i].time);
-    unsigned int min_index = std::distance(times.begin(),
-                                           std::min_element(times.begin(), times.end()));
+    for (unsigned int i = 0; i < nHits; i++)
+      times.push_back(hits[i].time);
+    unsigned int min_index = std::distance(
+        times.begin(), std::min_element(times.begin(), times.end()));
     h.time = hits[min_index].time;
-    for (unsigned int i=0; i<nHits; i++) {
+    for (unsigned int i = 0; i < nHits; i++) {
       h.posX += hits[i].posX * hits[i].edep;
       h.posY += hits[i].posY * hits[i].edep;
       h.posZ += hits[i].posZ * hits[i].edep;
@@ -81,16 +89,26 @@ Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner = kCen
     h.posX /= h.edep;
     h.posY /= h.edep;
     h.posZ /= h.edep;
+    break;
   }
-  else if (winner == kEnergyWinner) {
+
+  case kEnergyWinner: {
     std::vector<double> energies;
-    for (unsigned int i = 0; i<nHits; i++) energies.push_back(hits[i].edep);
-    unsigned int max_index = std::distance(energies.begin(),
-                                           std::max_element(energies.begin(), energies.end()));
+    // for (unsigned int i = 0; i<nHits; i++) energies.push_back(hits[i].edep);
+    unsigned int max_index = std::distance(
+        energies.begin(), std::max_element(energies.begin(), energies.end()));
     h.time = hits[max_index].time;
     h.posX = hits[max_index].posX;
     h.posY = hits[max_index].posY;
     h.posZ = hits[max_index].posZ;
+    break;
+  }
+
+  default: {
+    /// should never happen
+    assert(1 == 0);
+    break;
+  }
   }
   h.sourcePosX = hits[0].sourcePosX;
   h.sourcePosY = hits[0].sourcePosY;

--- a/goja/EventAnalysis.h
+++ b/goja/EventAnalysis.h
@@ -12,6 +12,8 @@
 #include "Hit.h"
 #include "Common.h"
 
+namespace event_analysis{
+
 enum EventType {
   kUnspecified = 0,
   kTrue = 1,
@@ -31,7 +33,7 @@ enum AveragingMethod {
 void sort_hits(std::vector<Hit> &hits, std::string key);
 Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner);
 
-namespace event_analysis{
+  void RunTests();
   /// returns number of hits above noise energy threshold, number of hits above Compton energy threshold, and selected hits
   std::tuple<int, int, std::vector<Hit>> select_coincident_hits(const std::vector<Hit> &hits, double compton_energy_threshold);
   /// returns number of singles above noise energy threshold, number of singles above Compton energy threshold, and selected singles

--- a/goja/EventAnalysis.h
+++ b/goja/EventAnalysis.h
@@ -31,19 +31,12 @@ enum AveragingMethod {
 void sort_hits(std::vector<Hit> &hits, std::string key);
 Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner);
 
-class EventAnalysis {
-
-  std::vector<Hit> coincident_hits;
-  int N;
-  int N0;
-
-public :
-
-  EventAnalysis();
-
-  void select_coincident_hits(const std::vector<Hit>& hits);
-  void select_coincident_singles(const std::vector<Hit> &hits);
-  EventType verify_type_of_coincidence(const Hit &h1,const Hit &h2) const;
+namespace event_analysis{
+  /// returns number of hits above noise energy threshold, number of hits above Compton energy threshold, and selected hits
+  std::tuple<int, int, std::vector<Hit>> select_coincident_hits(const std::vector<Hit> &hits, double compton_energy_threshold);
+  /// returns number of singles above noise energy threshold, number of singles above Compton energy threshold, and selected singles
+  std::tuple<int, int, std::vector<Hit>> select_coincident_singles(const std::vector<Hit> &hits, double compton_energy_threshold);
+  EventType verify_type_of_coincidence(const Hit &h1,const Hit &h2);
   void print_coincidences(const std::vector<Hit>& hits);
   void analyze_event(std::vector<Hit> &hits, bool hits_are_singles = true);
 

--- a/goja/EventAnalysis.h
+++ b/goja/EventAnalysis.h
@@ -1,8 +1,6 @@
 #ifndef EventAnalysis_h
 #define EventAnalysis_h
 
-using namespace std;
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -30,12 +28,12 @@ enum AveragingMethod {
   kEnergyWinner = 4
 };
 
-void sort_hits(vector<Hit> &hits, string key);
+void sort_hits(std::vector<Hit> &hits, std::string key);
 Hit add_hits(const std::vector<Hit> &hits, const AveragingMethod winner);
 
 class EventAnalysis {
 
-  vector<Hit> coincident_hits;
+  std::vector<Hit> coincident_hits;
   int N;
   int N0;
 
@@ -43,11 +41,11 @@ public :
 
   EventAnalysis();
 
-  void select_coincident_hits(vector<Hit> &hits);
+  void select_coincident_hits(const std::vector<Hit>& hits);
   void select_coincident_singles(const std::vector<Hit> &hits);
-  EventType verify_type_of_coincidence(Hit &h1, Hit &h2);
+  EventType verify_type_of_coincidence(const Hit &h1,const Hit &h2) const;
   void print_coincidences();
-  void analyze_event(vector<Hit> &hits, bool hits_are_singles = true);
+  void analyze_event(std::vector<Hit> &hits, bool hits_are_singles = true);
 
 };
 

--- a/goja/EventAnalysis.h
+++ b/goja/EventAnalysis.h
@@ -29,7 +29,7 @@ enum AveragingMethod {
 };
 
 void sort_hits(std::vector<Hit> &hits, std::string key);
-Hit add_hits(const std::vector<Hit> &hits, const AveragingMethod winner);
+Hit merge_hits(const std::vector<Hit> &hits, const AveragingMethod winner);
 
 class EventAnalysis {
 
@@ -44,7 +44,7 @@ public :
   void select_coincident_hits(const std::vector<Hit>& hits);
   void select_coincident_singles(const std::vector<Hit> &hits);
   EventType verify_type_of_coincidence(const Hit &h1,const Hit &h2) const;
-  void print_coincidences();
+  void print_coincidences(const std::vector<Hit>& hits);
   void analyze_event(std::vector<Hit> &hits, bool hits_are_singles = true);
 
 };

--- a/goja/Hit.cpp
+++ b/goja/Hit.cpp
@@ -1,4 +1,5 @@
 #include "Hit.h"
+using namespace std;
 
 Hit::Hit() {
 

--- a/goja/Hit.h
+++ b/goja/Hit.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <iostream>
 
-using namespace std;
-
 class Hit {
 
 public :

--- a/goja/Hit.h
+++ b/goja/Hit.h
@@ -4,9 +4,8 @@
 #include <string>
 #include <iostream>
 
-class Hit {
+struct Hit {
 
-public :
 
   int eventID = -1;          // ID of the event
   int volumeID = -1;         // volume detection in 'scanner' GATE systemType

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -4,8 +4,6 @@
 #include <TStyle.h>
 #include <TCanvas.h>
 
-using namespace std;
-
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -15,6 +13,7 @@ using namespace std;
 #include "EventAnalysis.h"
 #include "Common.h"
 
+using namespace std;
 
 LoopResults Hits::Loop(bool singles) {
 

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -101,8 +101,7 @@ void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigPar
     vector<Hit> event;
     int start_window_eventID = 0;
     double start_window_time = 0.;
-    for (unsigned int i = 0; i < hits.size(); i++) {
-      auto hit = hits[i];
+    for (const auto &hit : hits) {
       if (DEBUG)
         cout << "hit.edep=" << hit.edep << "\thit.time=" << hit.time
              << "\tstart_window_time=" << start_window_time

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -16,8 +16,8 @@
 using namespace std;
 
 LoopResults Hits::Loop(bool singles) {
-
-  ConfigParams params(singles);
+  ConfigParams params;
+  params.Init(singles);
 
   LoopResults lr;
   if (fChain == 0)
@@ -160,4 +160,21 @@ void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigPar
     if (DEBUG)
       cout << "lr.counter_compton_hits_over_the_ETH="
            << lr.counter_compton_hits_over_the_ETH << endl;
+}
+
+
+void Hits::RunTests() 
+{
+  Hit hit1;
+  hit1.time = 10;
+  Hit hit2;
+  hit2.time = 20;
+  vector<Hit> hits = {hit1,hit2};
+  ConfigParams params;
+  params.TIME_WINDOW =5;
+  params.EVENTS_SEPARATION_USING_TIME_WINDOW = 1;
+  params.EVENTS_SEPARATION_USING_IDS_OF_EVENTS = 0;
+  LoopResults res;
+  Hits::FindAndDumpCoincidences(hits,params,res);
+
 }

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -16,7 +16,6 @@
 using namespace std;
 
 LoopResults Hits::Loop(bool singles) {
-  std::cout << "starting Loop" << std::endl;
 
   double COMPTON_E_TH_0 = atof(getenv("GOJA_COMPTON_E_TH_0"))*1e3; // [COMPTON_E_TH_0]=keV
   double COMPTON_E_TH = atof(getenv("GOJA_COMPTON_E_TH"))*1e3; // [COMPTON_E_TH]=keV
@@ -27,14 +26,11 @@ LoopResults Hits::Loop(bool singles) {
   else EVENTS_SEPARATION_USING_TIME_WINDOW=0;
   EVENTS_SEPARATION_USING_IDS_OF_EVENTS = 1-EVENTS_SEPARATION_USING_TIME_WINDOW;
 
-  std::cout << "reading input params" << std::endl;
   LoopResults lr;
   if (fChain == 0)
     return lr;
 
-  std::cout << "fChain->GetEntriesFast()" << std::endl;
   Long64_t nentries = fChain->GetEntriesFast();
-  std::cout << "after fChain->GetEntriesFast()" << std::endl;
   vector<Hit> hits;
 
   auto hitIsCompton = [](const string& procName, const string& treeName)->bool { 
@@ -51,9 +47,9 @@ LoopResults Hits::Loop(bool singles) {
       return hit_is_proper;
   };
 
-  std::cout << "before for entries" << std::endl;
   for (Long64_t jentry=0; jentry<nentries; jentry++) {
     Long64_t ientry = LoadTree(jentry);
+    fChain->GetEntry(jentry);
     if (ientry < 0) break;
 
     Hit hit;
@@ -74,25 +70,15 @@ LoopResults Hits::Loop(bool singles) {
     std::string procName = std::string(processName);
 
     std::string tree_name = std::string(getenv("GOJA_TREE_NAME"));
-    std::cout << "before hitIsCompton" << std::endl;
-    std::cout << "procName:"<< procName << std::endl;
-    std::cout << "procesName:"<< procName.c_str() << std::endl;
-    std::cout << "procesName[0]:"<< processName[0] << std::endl;
-    std::cout << "procesName[1]:"<< processName[1] << std::endl;
-    std::cout << "tree_name:"<< tree_name << std::endl;
         
     if(hitIsCompton(procName, tree_name)) { // the photon is scattered using Compton scattering
       lr.counter_all_compton_hits += 1;
-      std::cout << "hitIsCompton" << std::endl;
       if (hitIsProper(hit, tree_name, PDGEncoding, nPhantomRayleigh, nCrystalRayleigh, COMPTON_E_TH_0)) {
-        std::cout << "hitIsProper" << std::endl;
         hits.push_back(hit);
       }
     }
   }
 
-  std::cout << "after for" << std::endl;
-  std::cout << "hits size-2:" << hits.size() << std::endl;
   if (EVENTS_SEPARATION_USING_TIME_WINDOW) {
     sort_hits(hits, "TIME");
   } else {
@@ -103,8 +89,6 @@ LoopResults Hits::Loop(bool singles) {
       assert(1 == 0);
     }
   }
-  std::cout << "after for" << std::endl;
-  std::cout << "hits size-1:" << hits.size() << std::endl;
 
   lr.counter_compton_hits_over_the_ETH0 = hits.size();
   if (DEBUG) {
@@ -115,22 +99,16 @@ LoopResults Hits::Loop(bool singles) {
          << lr.counter_compton_hits_over_the_ETH0 << endl;
   }
 
-  std::cout << "hits size0:" << hits.size() << std::endl;
-  std::cout << "before FindAndDumpCoincidences" << std::endl;
   FindAndDumpCoincidences(hits, COMPTON_E_TH, singles, EVENTS_SEPARATION_USING_TIME_WINDOW, EVENTS_SEPARATION_USING_IDS_OF_EVENTS, TIME_WINDOW, lr);
-  std::cout << "after FindAndDumpCoincidences" << std::endl;
   return lr;
 }
 
 void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, double compton_e_th, bool singles, int EVENTS_SEPARATION_USING_TIME_WINDOW, int EVENTS_SEPARATION_USING_IDS_OF_EVENTS, double TIME_WINDOW,  LoopResults& lr)
 {
-  std::cout << "starting  FindAndDumpCoincidences" << std::endl;
-  std::cout << "hits size1:" << hits.size() << std::endl;
     vector<Hit> event;
     int start_window_eventID = 0;
     double start_window_time = 0.;
     for (unsigned int i = 0; i < hits.size(); i++) {
-      std::cout << "starting  for loop for i:"<< i << std::endl;
       auto hit = hits[i];
       if (DEBUG)
         cout << "hit.edep=" << hit.edep << "\thit.time=" << hit.time
@@ -175,7 +153,6 @@ void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, double compton_
     }
     // the last event
 
-    std::cout << "before the last event" << std::endl;
     if (event.size() >= 1) {
       lr.multiplicities.push_back(event.size());
       if (event.size() >=
@@ -186,11 +163,8 @@ void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, double compton_
       event.clear(); // the last event is destroyed
     }
 
-    std::cout << "some real_time shit" << std::endl;
-    std::cout << "hits size:" << hits.size() << std::endl;
     lr.real_time = hits.at(hits.size() - 1).time - hits.at(0).time;
     if (DEBUG)
       cout << "lr.counter_compton_hits_over_the_ETH="
            << lr.counter_compton_hits_over_the_ETH << endl;
-    std::cout << "finito" << std::endl;
 }

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -92,7 +92,7 @@ LoopResults Hits::Loop(bool singles) {
          << lr.counter_compton_hits_over_the_ETH0 << endl;
   }
 
-  FindAndDumpCoincidences(hits, params, lr);
+  Hits::FindAndDumpCoincidences(hits, params, lr);
   return lr;
 }
 
@@ -129,8 +129,8 @@ void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigPar
           lr.multiplicities.push_back(event.size());
           if (event.size() >=
               2) { // if the number of hits in the current event is at least 2
-            EventAnalysis ea;
-            ea.analyze_event(event,
+            
+            event_analysis::analyze_event(event,
                              params.SINGLES); // then the current event is analyzed
           }
           event.clear();                 // the current event is destroyed
@@ -150,8 +150,7 @@ void Hits::FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigPar
       lr.multiplicities.push_back(event.size());
       if (event.size() >=
           2) { // if the number of hits in the last event is at least 2
-        EventAnalysis ea;
-        ea.analyze_event(event, params.SINGLES); // then the last event is analyzed
+        event_analysis::analyze_event(event, params.SINGLES); // then the last event is analyzed
       }
       event.clear(); // the last event is destroyed
     }

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -31,8 +31,21 @@ LoopResults Hits::Loop(bool singles) {
     return lr;
 
   Long64_t nentries = fChain->GetEntriesFast();
-
   vector<Hit> hits;
+
+  auto hitIsCompton = [](const string& procName, const string& treeName)->bool { 
+    if (treeName == "Hits")
+      return (procName=="Compton" or procName =="compt");
+    return true;
+  };
+
+  auto hitIsProper = [](const Hit& hit, const string& treeName, int pdgEncoding, int nPhantomRayleigh, int nCrystalRayleigh, double compton_e_th_0)->bool { 
+      bool hit_is_proper = hit.edep > compton_e_th_0 // deposited energy is larger than the noise threshold
+                           and nPhantomRayleigh==0 and nCrystalRayleigh==0; // the photon is not scattered using Rayleigh scattering
+      if (treeName == "Hits")
+          hit_is_proper = hit_is_proper and pdgEncoding==22; // gamma photon
+      return hit_is_proper;
+  };
 
   for (Long64_t jentry=0; jentry<nentries; jentry++) {
     Long64_t ientry = LoadTree(jentry);
@@ -55,84 +68,101 @@ LoopResults Hits::Loop(bool singles) {
     hit.nCrystalCompton = nCrystalCompton;
     string procName = string(processName);
 
-    bool hit_is_compton = true;
     std::string tree_name = std::string(getenv("GOJA_TREE_NAME"));
-    if (tree_name == "Hits")
-        hit_is_compton = (procName=="Compton" or procName=="compt"); // the photon is scattered using Compton scattering
-    if (hit_is_compton) {
+        
+    if(hitIsCompton(procName, tree_name)) { // the photon is scattered using Compton scattering
       lr.counter_all_compton_hits += 1;
-      bool hit_is_proper = hit.edep>COMPTON_E_TH_0 // deposited energy is bigger than the noise threshold
-                           and nPhantomRayleigh==0 and nCrystalRayleigh==0; // the photon is not scattered using Rayleigh scattering
-      if (tree_name == "Hits")
-          hit_is_proper = hit_is_proper and PDGEncoding==22; // gamma photon
-      if (hit_is_proper) {
+      if (hitIsProper(hit, tree_name, PDGEncoding, nPhantomRayleigh, nCrystalRayleigh, COMPTON_E_TH_0)) {
         hits.push_back(hit);
       }
     }
   }
 
-  if (EVENTS_SEPARATION_USING_TIME_WINDOW) sort_hits(hits, "TIME");
-  else if (EVENTS_SEPARATION_USING_IDS_OF_EVENTS) sort_hits(hits, "EVENTID");
-
-  lr.counter_compton_hits_over_the_ETH0 = hits.size();
-  if (DEBUG) {
-    cout.setf(ios::fixed);
-    cout << "lr.counter_all_compton_hits=" << lr.counter_all_compton_hits << endl;
-    cout << "lr.counter_compton_hits_over_the_ETH0=" << lr.counter_compton_hits_over_the_ETH0 << endl;
+  if (EVENTS_SEPARATION_USING_TIME_WINDOW) {
+    sort_hits(hits, "TIME");
+  } else {
+    if (EVENTS_SEPARATION_USING_IDS_OF_EVENTS) {
+      sort_hits(hits, "EVENTID");
+    } else {
+      // this should never happen
+      assert(1 == 0);
+    }
   }
 
-  vector<Hit> event;
-  int start_window_eventID = 0;
-  double start_window_time = 0.;
-  for (unsigned int i=0; i<hits.size(); i++) {
-    auto hit = hits[i];
-    if(DEBUG) cout << "hit.edep=" << hit.edep << "\thit.time=" << hit.time << "\tstart_window_time=" << start_window_time << "\thit.eventID=" << hit.eventID << endl;
-    if (event.size()==0) {
-      if (hit.edep>COMPTON_E_TH) {
-        event.push_back(hit); // start forming the event with the hit with edep>E_TH
-        start_window_time = hit.time;
-        start_window_eventID = hit.eventID;
-        lr.counter_compton_hits_over_the_ETH += 1;
-      }
+    lr.counter_compton_hits_over_the_ETH0 = hits.size();
+    if (DEBUG) {
+      cout.setf(ios::fixed);
+      cout << "lr.counter_all_compton_hits=" << lr.counter_all_compton_hits
+           << endl;
+      cout << "lr.counter_compton_hits_over_the_ETH0="
+           << lr.counter_compton_hits_over_the_ETH0 << endl;
     }
-    else {
-      bool hit_in_event = false;
-      if (EVENTS_SEPARATION_USING_TIME_WINDOW) {
-        hit_in_event = (hit.time - start_window_time) < TIME_WINDOW;
-      } else {
-        if (EVENTS_SEPARATION_USING_IDS_OF_EVENTS)
-          hit_in_event = hit.eventID == start_window_eventID;
-      }
-      if (hit_in_event) { // if the current hit belongs to the current event
-        event.push_back(hit); // then it is added to the current event
-      }
-      else { // if the current hit does not belong to the current event
-        lr.multiplicities.push_back(event.size());
-        if (event.size()>=2) { // if the number of hits in the current event is at least 2
-          EventAnalysis ea;
-          ea.analyze_event(event, singles); // then the current event is analyzed
-        }
-        event.clear(); // the current event is destroyed
-        if (hit.edep>COMPTON_E_TH) { // start forming the event with the hit with edep>E_TH
-          event.push_back(hit);
+
+    FindAndDumpCoincidences(hits, COMPTON_E_TH, singles, EVENTS_SEPARATION_USING_TIME_WINDOW, EVENTS_SEPARATION_USING_IDS_OF_EVENTS, TIME_WINDOW, lr);
+    return lr;
+  }
+
+void Hits::FindAndDumpCoincidences(std::vector<Hit> &hits, double compton_e_th, bool singles, int EVENTS_SEPARATION_USING_TIME_WINDOW, int EVENTS_SEPARATION_USING_IDS_OF_EVENTS, double TIME_WINDOW,  LoopResults& lr)
+{
+    vector<Hit> event;
+    int start_window_eventID = 0;
+    double start_window_time = 0.;
+    for (unsigned int i = 0; i < hits.size(); i++) {
+      auto hit = hits[i];
+      if (DEBUG)
+        cout << "hit.edep=" << hit.edep << "\thit.time=" << hit.time
+             << "\tstart_window_time=" << start_window_time
+             << "\thit.eventID=" << hit.eventID << endl;
+      if (event.size() == 0) {
+        if (hit.edep > compton_e_th) {
+          event.push_back(
+              hit); // start forming the event with the hit with edep>E_TH
           start_window_time = hit.time;
           start_window_eventID = hit.eventID;
           lr.counter_compton_hits_over_the_ETH += 1;
         }
+      } else {
+        bool hit_in_event = false;
+        if (EVENTS_SEPARATION_USING_TIME_WINDOW) {
+          hit_in_event = (hit.time - start_window_time) < TIME_WINDOW;
+        } else {
+          if (EVENTS_SEPARATION_USING_IDS_OF_EVENTS)
+            hit_in_event = hit.eventID == start_window_eventID;
+        }
+        if (hit_in_event) { // if the current hit belongs to the current event
+          event.push_back(hit); // then it is added to the current event
+        } else { // if the current hit does not belong to the current event
+          lr.multiplicities.push_back(event.size());
+          if (event.size() >=
+              2) { // if the number of hits in the current event is at least 2
+            EventAnalysis ea;
+            ea.analyze_event(event,
+                             singles); // then the current event is analyzed
+          }
+          event.clear();                 // the current event is destroyed
+          if (hit.edep > compton_e_th) { // start forming the event with the hit
+                                         // with edep>E_TH
+            event.push_back(hit);
+            start_window_time = hit.time;
+            start_window_eventID = hit.eventID;
+            lr.counter_compton_hits_over_the_ETH += 1;
+          }
+        }
       }
     }
-  }
-  // the last event
-  if (event.size()>=1) {
-    lr.multiplicities.push_back(event.size());
-    if (event.size()>=2) { // if the number of hits in the last event is at least 2
-      EventAnalysis ea;
-      ea.analyze_event(event, singles); // then the last event is analyzed
+    // the last event
+    if (event.size() >= 1) {
+      lr.multiplicities.push_back(event.size());
+      if (event.size() >=
+          2) { // if the number of hits in the last event is at least 2
+        EventAnalysis ea;
+        ea.analyze_event(event, singles); // then the last event is analyzed
+      }
+      event.clear(); // the last event is destroyed
     }
-    event.clear(); // the last event is destroyed
-  }
 
-  lr.real_time = hits[hits.size()-1].time - hits[0].time;
-  if(DEBUG) cout << "lr.counter_compton_hits_over_the_ETH=" << lr.counter_compton_hits_over_the_ETH << endl;
-  return lr;
+    lr.real_time = hits[hits.size() - 1].time - hits[0].time;
+    if (DEBUG)
+      cout << "lr.counter_compton_hits_over_the_ETH="
+           << lr.counter_compton_hits_over_the_ETH << endl;
 }

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -9,10 +9,12 @@ using namespace std;
 #include <iostream>
 #include <fstream>
 #include <sstream>
+#include <cassert>
 #include <math.h>
 
 #include "EventAnalysis.h"
 #include "Common.h"
+
 
 LoopResults Hits::Loop(bool singles) {
 
@@ -30,15 +32,12 @@ LoopResults Hits::Loop(bool singles) {
     return lr;
 
   Long64_t nentries = fChain->GetEntriesFast();
-  Long64_t nbytes = 0, nb = 0;
 
   vector<Hit> hits;
 
   for (Long64_t jentry=0; jentry<nentries; jentry++) {
     Long64_t ientry = LoadTree(jentry);
     if (ientry < 0) break;
-    nb = fChain->GetEntry(jentry);
-    nbytes += nb;
 
     Hit hit;
     hit.eventID = eventID;
@@ -98,9 +97,13 @@ LoopResults Hits::Loop(bool singles) {
       }
     }
     else {
-      bool hit_in_event;
-      if (EVENTS_SEPARATION_USING_TIME_WINDOW) hit_in_event = (hit.time-start_window_time)<TIME_WINDOW;
-      else if (EVENTS_SEPARATION_USING_IDS_OF_EVENTS) hit_in_event = hit.eventID==start_window_eventID;
+      bool hit_in_event = false;
+      if (EVENTS_SEPARATION_USING_TIME_WINDOW) {
+        hit_in_event = (hit.time - start_window_time) < TIME_WINDOW;
+      } else {
+        if (EVENTS_SEPARATION_USING_IDS_OF_EVENTS)
+          hit_in_event = hit.eventID == start_window_eventID;
+      }
       if (hit_in_event) { // if the current hit belongs to the current event
         event.push_back(hit); // then it is added to the current event
       }

--- a/goja/Hits.C
+++ b/goja/Hits.C
@@ -73,10 +73,10 @@ LoopResults Hits::Loop(bool singles) {
   }
 
   if (params.EVENTS_SEPARATION_USING_TIME_WINDOW) {
-    sort_hits(hits, "TIME");
+    event_analysis::sort_hits(hits, "TIME");
   } else {
     if (params.EVENTS_SEPARATION_USING_IDS_OF_EVENTS) {
-      sort_hits(hits, "EVENTID");
+      event_analysis::sort_hits(hits, "EVENTID");
     } else {
       // this should never happen
       assert(1 == 0);

--- a/goja/Hits.h
+++ b/goja/Hits.h
@@ -13,7 +13,7 @@
 #include "Hit.h"
 
 struct ConfigParams {
-  explicit ConfigParams(bool singles) {
+  void Init(bool singles) {
     COMPTON_E_TH_0 = atof(getenv("GOJA_COMPTON_E_TH_0"))*1e3; // [COMPTON_E_TH_0]=keV
     COMPTON_E_TH = atof(getenv("GOJA_COMPTON_E_TH"))*1e3; // [COMPTON_E_TH]=keV
     TIME_WINDOW = atof(getenv("GOJA_TIME_WINDOW"))*1e3; // [TIME_WINDOW]=ps
@@ -119,7 +119,8 @@ public :
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
 
-   void FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigParams& params, LoopResults& lr);
+   static void FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigParams& params, LoopResults& lr);
+   static void RunTests();
 };
 
 #endif

--- a/goja/Hits.h
+++ b/goja/Hits.h
@@ -14,12 +14,12 @@
 
 struct LoopResults {
   LoopResults() : real_time(0.),
-                  multiplicities(vector<int>()),
+                  multiplicities(std::vector<int>()),
                   counter_all_compton_hits(0),
                   counter_compton_hits_over_the_ETH0(0),
                   counter_compton_hits_over_the_ETH(0) {}
   double real_time;
-  vector<int> multiplicities;
+  std::vector<int> multiplicities;
   int counter_all_compton_hits;
   int counter_compton_hits_over_the_ETH0;
   int counter_compton_hits_over_the_ETH;
@@ -200,7 +200,7 @@ void Hits::Init(TTree *tree)
      fChain->SetBranchAddress("RayleighCrystal", &nCrystalRayleigh, &b_nCrystalRayleigh);
    }
    fChain->SetBranchAddress("time", &time, &b_time);
-   string systemType = string(getenv("GOJA_SYSTEM_TYPE"));
+  std::string systemType = std::string(getenv("GOJA_SYSTEM_TYPE"));
    if (systemType == "cylindricalPET")
      fChain->SetBranchAddress("rsectorID", &rsectorID, &b_rsectorID);
    fChain->SetBranchAddress("layerID", &layerID, &b_layerID);

--- a/goja/Hits.h
+++ b/goja/Hits.h
@@ -12,6 +12,27 @@
 
 #include "Hit.h"
 
+struct ConfigParams {
+  explicit ConfigParams(bool singles) {
+    COMPTON_E_TH_0 = atof(getenv("GOJA_COMPTON_E_TH_0"))*1e3; // [COMPTON_E_TH_0]=keV
+    COMPTON_E_TH = atof(getenv("GOJA_COMPTON_E_TH"))*1e3; // [COMPTON_E_TH]=keV
+    TIME_WINDOW = atof(getenv("GOJA_TIME_WINDOW"))*1e3; // [TIME_WINDOW]=ps
+    int sep = int(atof(getenv("GOJA_SEP")));
+    if (sep==0) EVENTS_SEPARATION_USING_TIME_WINDOW=1;
+    else EVENTS_SEPARATION_USING_TIME_WINDOW=0;
+    EVENTS_SEPARATION_USING_IDS_OF_EVENTS = 1-EVENTS_SEPARATION_USING_TIME_WINDOW;
+    SINGLES = singles;
+  }
+
+  double COMPTON_E_TH_0 = -1;
+  double COMPTON_E_TH= -1;
+  double TIME_WINDOW =-1;
+  int EVENTS_SEPARATION_USING_TIME_WINDOW = -1; 
+  int EVENTS_SEPARATION_USING_IDS_OF_EVENTS = -1; 
+  bool SINGLES = false;
+
+};
+
 struct LoopResults {
   LoopResults() : real_time(0.),
                   multiplicities(std::vector<int>()),
@@ -98,7 +119,7 @@ public :
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
 
-   void FindAndDumpCoincidences(const std::vector<Hit> &hits, double compton_e_th, bool singles, int EVENTS_SEPARATION_USING_TIME_WINDOW, int EVENTS_SEPARATION_USING_IDS_OF_EVENTS, double TIME_WINDOW, LoopResults& lr);
+   void FindAndDumpCoincidences(const std::vector<Hit> &hits, const ConfigParams& params, LoopResults& lr);
 };
 
 #endif

--- a/goja/Hits.h
+++ b/goja/Hits.h
@@ -97,6 +97,8 @@ public :
    virtual LoopResults Loop(bool singles);
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
+
+   void FindAndDumpCoincidences(std::vector<Hit> &hits, double compton_e_th, bool singles, int EVENTS_SEPARATION_USING_TIME_WINDOW, int EVENTS_SEPARATION_USING_IDS_OF_EVENTS, double TIME_WINDOW, LoopResults& lr);
 };
 
 #endif

--- a/goja/Hits.h
+++ b/goja/Hits.h
@@ -260,4 +260,4 @@ void Hits::Show(Long64_t entry)
    fChain->Show(entry);
 }
 
-#endif // #ifdef Hits_cxx
+#endif

--- a/goja/Hits.h
+++ b/goja/Hits.h
@@ -98,7 +98,7 @@ public :
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
 
-   void FindAndDumpCoincidences(std::vector<Hit> &hits, double compton_e_th, bool singles, int EVENTS_SEPARATION_USING_TIME_WINDOW, int EVENTS_SEPARATION_USING_IDS_OF_EVENTS, double TIME_WINDOW, LoopResults& lr);
+   void FindAndDumpCoincidences(const std::vector<Hit> &hits, double compton_e_th, bool singles, int EVENTS_SEPARATION_USING_TIME_WINDOW, int EVENTS_SEPARATION_USING_IDS_OF_EVENTS, double TIME_WINDOW, LoopResults& lr);
 };
 
 #endif

--- a/goja/goja.cpp
+++ b/goja/goja.cpp
@@ -43,12 +43,14 @@ namespace po = boost::program_options;
 int main (int argc, char* argv[]) {
 
   bool singles = false;
+  bool areTestsOn = false;
 
   po::options_description desc("\nGOJA (GATE Output J-PET Analyzer) help\n\nAllowed options");
   desc.add_options()
 
   ("help", "produce help message")
-
+  // running tests:
+  ("test",po::bool_switch(&areTestsOn), "runs tests")
   // Forming coincidences options:
   ("eth", po::value<string>(), "fixed energy threshold [MeV] (default: 0.2 MeV)")
   ("eth0", po::value<string>(), "noise energy threshold [MeV] (default: 0.0 MeV)")
@@ -85,6 +87,11 @@ int main (int argc, char* argv[]) {
 
   if (argc == 1 or vm.count("help")) {
     cout << desc << "\n";
+    return 1;
+  }
+
+  if(areTestsOn) {
+    Hits::RunTests();
     return 1;
   }
 

--- a/goja/goja.cpp
+++ b/goja/goja.cpp
@@ -9,6 +9,7 @@
 
 #include "boost/program_options.hpp"
 
+#include "EventAnalysis.h"
 #include "Hits.h"
 
 #define SET_GOJA_ENV_VAR(option, variable, default_value) { \
@@ -92,6 +93,7 @@ int main (int argc, char* argv[]) {
 
   if(areTestsOn) {
     Hits::RunTests();
+    event_analysis::RunTests();
     return 1;
   }
 


### PR DESCRIPTION
- remove unused variables
- remove using namespace in headers
- add header guards in all headers
- change `#define` to const variables
- change Hit from class to struct
- introduce a struct ConfigParams to store all parameters
- simplify the code, e.g. 
- add the option to call tests and define a place for tests
- downgrade requirements in CmakeLists.txt to ROOT 6.22
- EventAnalysis became namespace, and most of the methods became pure functions